### PR TITLE
pkgs/build-sandbox: remove malloc.h

### DIFF
--- a/pkgs/build-support/build-sandbox/src/setup.c
+++ b/pkgs/build-support/build-sandbox/src/setup.c
@@ -9,7 +9,6 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
-#include <malloc.h>
 #include <sched.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
The standard functins in `malloc.h` are exported by `stdlib.h`, and
`malloc.h` is highly linux-specific.

See
https://stackoverflow.com/questions/56463049/should-mac-osx-have-a-malloc-h-file/56463133#56463133
and
https://stackoverflow.com/questions/12973311/difference-between-stdlib-h-and-malloc-h