### PR TITLE
treewide: use `runCommandLocal` where applicable

### DIFF
--- a/machines/aszlig/managed/shakti.nix
+++ b/machines/aszlig/managed/shakti.nix
@@ -26,7 +26,7 @@
   # information and the monitor is also very weird because it doesn't
   # understand the fallback modes.
   boot.kernelParams = [ "drm_kms_helper.edid_firmware=edid/weird.bin" ];
-  hardware.firmware = lib.singleton (pkgs.runCommand "weird-edid" {} ''
+  hardware.firmware = lib.singleton (pkgs.runCommandLocal "weird-edid" {} ''
     mkdir -p "$out/lib/firmware/edid"
     base64 -d > "$out/lib/firmware/edid/weird.bin" <<EOF
     AP///////wAEaaEiAQEBASQRAQOALx1477U1pVZKmiUQUFS/74BxT4GAlQCzAAEBlQ+BioFA

--- a/machines/profpatsch/haku.nix
+++ b/machines/profpatsch/haku.nix
@@ -111,7 +111,7 @@ in
             rev = "ef02aa8f074d0d5209839cd12ba7a67685fdaa05";
             sha256 = "1hr2si73lam463pcf25napfbk0zb30kgv3ncc0ahv6wndjpsvg7z";
           };
-          in pkgs.runCommand "lojbanistan-www" {} ''
+          in pkgs.runCommandLocal "lojbanistan-www" {} ''
             mkdir $out
             echo "coi do" > $out/index.html
             ${pkgs.imagemagick}/bin/convert \

--- a/machines/profpatsch/pkgs.nix
+++ b/machines/profpatsch/pkgs.nix
@@ -97,7 +97,7 @@ let
         notify-send = "${pkgs.libnotify.overrideAttrs (old: {
           patches = old.patches or [] ++ [ ./patches/libnotify.patch ];
         })}/bin/notify-send";
-    in pkgs.runCommand "pyrnotify.py" {} ''
+    in pkgs.runCommandLocal "pyrnotify.py" {} ''
       substitute "${src}/pyrnotify.py" $out \
         --replace 'notify-send' '${notify-send}'
     '';

--- a/modules/core/lazy-packages.nix
+++ b/modules/core/lazy-packages.nix
@@ -12,7 +12,7 @@ let
   # The command used to fetch the store path from the binary cache.
   fetchSubstitute = "${escapeShellArg "${pkgs.nix}/bin/nix-store"} -r";
 
-  mkWrapper = package: pkgs.runCommand "${package.name}-lazy" {
+  mkWrapper = package: pkgs.runCommandLocal "${package.name}-lazy" {
     inherit package;
   } ''
     encoded="$(echo "$package" | ${encoder})"

--- a/modules/hardware/t100ha/default.nix
+++ b/modules/hardware/t100ha/default.nix
@@ -8,7 +8,7 @@ in {
   options.vuizvui.hardware.t100ha.enable = lib.mkEnableOption desc;
 
   config = lib.mkIf cfg.enable {
-    hardware.firmware = lib.singleton (pkgs.runCommand "t100ha-firmware" {
+    hardware.firmware = lib.singleton (pkgs.runCommandLocal "t100ha-firmware" {
       params = ./brcmfmac43340-sdio.txt;
       fwpkg = pkgs.firmwareLinuxNonfree;
       install = "install -vD -m 0644";

--- a/modules/user/aszlig/services/vlock/default.nix
+++ b/modules/user/aszlig/services/vlock/default.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.vuizvui.user.aszlig.services.vlock;
 
-  messageFile = pkgs.runCommand "message.cat" {} ''
+  messageFile = pkgs.runCommandLocal "message.cat" {} ''
     echo -en '\e[H\e[2J\e[?25l' > "$out"
     "${pkgs.vuizvui.aszlig.aacolorize}/bin/aacolorize" \
       "${./message.cat}" "${./message.colmap}" \

--- a/modules/user/openlab/speedtest.nix
+++ b/modules/user/openlab/speedtest.nix
@@ -6,7 +6,7 @@ let
   bin = drv: name: "${lib.getBin drv}/bin/${name}";
   cfg = config.vuizvui.user.openlab.speedtest;
 
-  py = pkgs.runCommand "speedtest.py" {} ''
+  py = pkgs.runCommandLocal "speedtest.py" {} ''
     cat ${./speedtest.py} \
       | sed -e 's|^PING_BIN =.*$|PING_BIN = "${config.security.wrapperDir}/ping"|' \
       > $out

--- a/pkgs/profpatsch/default.nix
+++ b/pkgs/profpatsch/default.nix
@@ -54,16 +54,10 @@ let
       };
     in import src { nixpkgs = pkgs; };
 
-  runCommandLocal = name: args: cmd:
-    pkgs.runCommand name (args // {
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    }) cmd;
-
   testing = import ./testing {
     inherit stdenv lib;
     inherit (runExeclineFns) runExecline;
-    inherit (pkgs) runCommand;
+    inherit (pkgs) runCommandLocal;
     bin = getBins pkgs.s6PortableUtils [ "s6-touch" "s6-echo" ];
   };
 

--- a/pkgs/profpatsch/display-infos/default.nix
+++ b/pkgs/profpatsch/display-infos/default.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, writeText, python3, libnotify, bc, sfttime }:
+{ lib, runCommandLocal, writeText, python3, libnotify, bc, sfttime }:
 
 let
   name = "display-infos-0.1.0";
@@ -61,7 +61,7 @@ let
   '';
 
 in
-  with lib; runCommand "display-infos" {
+  with lib; runCommandLocal "display-infos" {
     meta.description = "Script to display time & battery";
   } ''
     substitute ${script} script \

--- a/pkgs/profpatsch/nman/default.nix
+++ b/pkgs/profpatsch/nman/default.nix
@@ -1,6 +1,6 @@
-{ lib, runCommandNoCC, go }:
+{ lib, runCommand, go }:
 
-runCommandNoCC "nman" {
+runCommand "nman" {
   meta = with lib; {
     description = "Invoke manpage in temporary nix-shell";
     license = licenses.gpl3;

--- a/pkgs/profpatsch/sandbox.nix
+++ b/pkgs/profpatsch/sandbox.nix
@@ -26,7 +26,7 @@ let
       mount = "${pkgs.utillinux}/bin/mount";
       unshare = "${pkgs.utillinux}/bin/unshare";
       # this is the directory the sandbox runs under (in a separate mount namespace)
-      newroot = pkgs.runCommand "sandbox-root" {} ''mkdir "$out"'';
+      newroot = pkgs.runCommandLocal "sandbox-root" {} ''mkdir "$out"'';
       # this runs in a separate namespace, sets up a chroot root
       # and then chroots into the new root.
       sandbox = writeExecline "sandbox" {} (builtins.concatLists [

--- a/pkgs/profpatsch/testing/default.nix
+++ b/pkgs/profpatsch/testing/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, lib
+{ stdenv, runCommandLocal, lib
 , runExecline, bin }:
 
 let
@@ -15,13 +15,11 @@ let
   drvSeqL = drvDeps: drvOut: let
   drvOutOutputs = drvOut.outputs or ["out"];
   in
-    runCommand drvOut.name {
+    runCommandLocal drvOut.name {
       # we inherit all attributes in order to replicate
       # the original derivation as much as possible
       outputs = drvOutOutputs;
       passthru = drvOut.drvAttrs;
-      preferLocalBuild = true;
-      allowSubstitutes = false;
       # depend on drvDeps (by putting it in builder context)
       inherit drvDeps;
     }

--- a/pkgs/taalo-build/default.nix
+++ b/pkgs/taalo-build/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, runCommand, coreutils, nixUnstable }:
+{ stdenv, lib, runCommandLocal, coreutils, nixUnstable }:
 
 let
   nixRemote = "ssh-ng://nix-remote-build@taalo.headcounter.org?compress=true";
@@ -16,7 +16,7 @@ let
   emitScript = content:
     "echo -n ${lib.escapeShellArg "#!${stdenv.shell}\nset -e\n${content}"}";
 
-in runCommand "taalo-build" {} ''
+in runCommandLocal "taalo-build" {} ''
   mkdir -p "$out/bin"
 
   ${emitScript (''

--- a/release.nix
+++ b/release.nix
@@ -81,7 +81,7 @@ in with pkgsUpstream.lib; with builtins; {
   machines = let
     # We need to expose all the real builds within vuizvui.lazyPackages to make
     # sure they don't get garbage collected on the Hydra instance.
-    wrapLazy = machine: pkgsUpstream.runCommand machine.build.name {
+    wrapLazy = machine: pkgsUpstream.runCommandLocal machine.build.name {
       fakeRuntimeDeps = machine.eval.config.vuizvui.lazyPackages;
       product = machine.build;
     } ''
@@ -97,7 +97,7 @@ in with pkgsUpstream.lib; with builtins; {
     buildIso = attrs: let
       name = attrs.iso.config.networking.hostName;
       cond = attrs.iso.config.vuizvui.createISO;
-    in if !cond then {} else pkgsUpstream.runCommand "vuizvui-iso-${name}" {
+    in if !cond then {} else pkgsUpstream.runCommandLocal "vuizvui-iso-${name}" {
       meta.description = "Live CD/USB stick of ${name}";
       iso = attrs.iso.config.system.build.isoImage;
       passthru.config = attrs.iso.config;

--- a/tests/sandbox.nix
+++ b/tests/sandbox.nix
@@ -19,7 +19,7 @@
 
     environment.systemPackages = let
       mkNestedLinksTo = drv: let
-        mkLink = name: to: pkgs.runCommand name { inherit to; } ''
+        mkLink = name: to: pkgs.runCommandLocal name { inherit to; } ''
           ln -s "$to" "$out"
         '';
       in mkLink "nested-1" (mkLink "nested-2" (mkLink "nested-3" drv));
@@ -50,7 +50,7 @@
           # symlinks.
           lfile="$(< ${mkNestedLinksTo (pkgs.writeText "target" "file")})"
           test "$lfile" = file
-          ldir="$(< ${mkNestedLinksTo (pkgs.runCommand "target" {} ''
+          ldir="$(< ${mkNestedLinksTo (pkgs.runCommandLocal "target" {} ''
             mkdir -p "$out"
             echo dir > "$out/canary"
           '')}/canary)"


### PR DESCRIPTION
`runCommandLocal` was added to nixpkgs in
https://github.com/NixOS/nixpkgs/pull/74642
to speed up trivial `runCommand` derivations by always building them
locally. We have a few places where that’s good to use.