### PR TITLE
treewide: stdenv.lib -> pkgs.lib

### DIFF
--- a/pkgs/aszlig/axbo/default.nix
+++ b/pkgs/aszlig/axbo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, jdk, jre, ant, makeWrapper
+{ stdenv, lib, fetchurl, fetchFromGitHub, jdk, jre, ant, makeWrapper
 , commonsLogging, librxtx_java
 }:
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     "swingx-all-1.6.4"
   ];
 
-  installPhase = with stdenv.lib; let
+  installPhase = with lib; let
     classpath = makeSearchPath "share/java/\\*" [
       "$out"
       commonsLogging

--- a/pkgs/aszlig/lockdev/default.nix
+++ b/pkgs/aszlig/lockdev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, lib, fetchurl, perl }:
 
 let
   baseurl = "ftp://ftp.debian.org/debian/pool/main/l/lockdev/";
@@ -8,7 +8,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ perl ];
 
-  patches = stdenv.lib.singleton (fetchurl {
+  patches = lib.singleton (fetchurl {
     url = baseurl + "lockdev_1.0.3-1.5.diff.gz";
     sha256 = "1l3pq1nfb5qx3i91cjaiz3c53368gw6m28a5mv9391n5gmsdmi3r";
   });

--- a/pkgs/games/gog/fetch-gog/default.nix
+++ b/pkgs/games/gog/fetch-gog/default.nix
@@ -170,7 +170,7 @@ let
     '';
   };
 
-  mkPyStr = str: "'${stdenv.lib.escape ["'" "\\"] (toString str)}'";
+  mkPyStr = str: "'${lib.escape ["'" "\\"] (toString str)}'";
 
   fetcher = writeText "fetch-gog.py" ''
     import sys, socket, time

--- a/pkgs/games/humblebundle/brigador.nix
+++ b/pkgs/games/humblebundle/brigador.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, makeWrapper, fetchHumbleBundle, writeText
+{ stdenv, lib, fetchurl, makeWrapper, fetchHumbleBundle, writeText
 , SDL2, libGL, glew, freeimage
 }:
 
 let
-  oldGLEW = glew.overrideDerivation (stdenv.lib.const rec {
+  oldGLEW = glew.overrideDerivation (lib.const rec {
     name = "glew-1.12.0";
     src = fetchurl {
       url = "mirror://sourceforge/glew/${name}.tgz";
@@ -40,7 +40,7 @@ in stdenv.mkDerivation {
         return call(buf, __VA_ARGS__); \
       }
 
-    ${stdenv.lib.concatMapStrings (fun: ''
+    ${lib.concatMapStrings (fun: ''
       FILE *${fun}(const char *path, const char *mode) {
         static FILE *(*_${fun}) (const char *, const char *) = NULL;
         if (_${fun} == NULL) _${fun} = dlsym(RTLD_NEXT, "${fun}");
@@ -63,8 +63,8 @@ in stdenv.mkDerivation {
   '';
 
   patchPhase = let
-    fmodRpath = stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ];
-    rpath = stdenv.lib.makeLibraryPath [ "$out" SDL2 libGL oldGLEW freeimage ];
+    fmodRpath = lib.makeLibraryPath [ "$out" stdenv.cc.cc ];
+    rpath = lib.makeLibraryPath [ "$out" SDL2 libGL oldGLEW freeimage ];
   in ''
     for fmod in lib/libfmod*.so*; do
       patchelf --set-rpath "${fmodRpath}" "$fmod"

--- a/pkgs/games/humblebundle/cavestoryplus.nix
+++ b/pkgs/games/humblebundle/cavestoryplus.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, makeWrapper, SDL, libGL }:
+{ stdenv, lib, fetchHumbleBundle, makeWrapper, SDL, libGL }:
 
 stdenv.mkDerivation rec {
   name = "cave-story-plus-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper ];
 
   patchPhase = let
-    rpath = stdenv.lib.makeLibraryPath [
+    rpath = lib.makeLibraryPath [
       SDL "$out" stdenv.cc.cc libGL
     ];
   in ''

--- a/pkgs/games/humblebundle/dott.nix
+++ b/pkgs/games/humblebundle/dott.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, libGL, libpulseaudio, alsaLib, libudev
+{ stdenv, lib, fetchHumbleBundle, libGL, libpulseaudio, alsaLib, libudev
 , writeText
 }:
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     }
   '';
 
-  rpath = stdenv.lib.makeLibraryPath [
+  rpath = lib.makeLibraryPath [
     libGL stdenv.cc.cc libpulseaudio alsaLib.out libudev
   ];
 

--- a/pkgs/games/humblebundle/fetch-humble-bundle/default.nix
+++ b/pkgs/games/humblebundle/fetch-humble-bundle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, curl, cacert, writeText, writeScript, fetchFromGitHub, fetchpatch
+{ stdenv, lib, curl, cacert, writeText, writeScript, fetchFromGitHub, fetchpatch
 , python, python3, pythonPackages
 
 # Dependencies for the captcha solver
@@ -34,7 +34,7 @@ let
       waitForResponse();
     '';
 
-    escapeCString = stdenv.lib.replaceStrings ["\"" "\n"] ["\\\"" "\\n"];
+    escapeCString = lib.replaceStrings ["\"" "\n"] ["\\\"" "\\n"];
 
     application = writeText "captcha.cc" ''
       #include <QApplication>
@@ -136,7 +136,7 @@ let
     propagatedBuildInputs = [ pythonPackages.requests ];
   };
 
-  pyStr = str: "'${stdenv.lib.escape ["'" "\\"] str}'";
+  pyStr = str: "'${lib.escape ["'" "\\"] str}'";
 
   getDownloadURL = writeText "gethburl.py" ''
     import socket, sys, time, humblebundle

--- a/pkgs/games/humblebundle/fez.nix
+++ b/pkgs/games/humblebundle/fez.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchHumbleBundle, unzip, mono, openal, SDL2 }:
+{ stdenv, lib, fetchHumbleBundle, unzip, mono, openal, SDL2 }:
 
 let
   version = "1.0.2";
-  usVersion = stdenv.lib.replaceChars ["."] ["_"] version;
+  usVersion = lib.replaceChars ["."] ["_"] version;
 in stdenv.mkDerivation rec {
   name = "fez-${version}";
   version = "09152013";
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   buildPhase = ''
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${stdenv.lib.makeLibraryPath [ mono openal SDL2 ]}" \
+      --set-rpath "${lib.makeLibraryPath [ mono openal SDL2 ]}" \
       FEZ.bin.x86_64
   '';
 

--- a/pkgs/games/humblebundle/ftl.nix
+++ b/pkgs/games/humblebundle/ftl.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, makeWrapper, SDL, libGL, libdevil, freetype }:
+{ stdenv, lib, fetchHumbleBundle, makeWrapper, SDL, libGL, libdevil, freetype }:
 
 stdenv.mkDerivation rec {
   name = "ftl-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper ];
 
   patchPhase = let
-    rpath = stdenv.lib.makeLibraryPath [
+    rpath = lib.makeLibraryPath [
       SDL "$out" stdenv.cc.cc libGL libdevil freetype
     ];
   in ''

--- a/pkgs/games/humblebundle/grim-fandango.nix
+++ b/pkgs/games/humblebundle/grim-fandango.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, libGL, libpulseaudio, alsaLib, SDL2, writeText
+{ stdenv, lib, fetchHumbleBundle, libGL, libpulseaudio, alsaLib, SDL2, writeText
 , xorg
 }:
 
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     }
   '';
 
-  rpath = stdenv.lib.makeLibraryPath [
+  rpath = lib.makeLibraryPath [
     libGL stdenv.cc.cc libpulseaudio alsaLib.out SDL2 xorg.libX11
   ];
 

--- a/pkgs/games/humblebundle/guacamelee.nix
+++ b/pkgs/games/humblebundle/guacamelee.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, unzip, SDL2, libGL, writeText, makeWrapper }:
+{ stdenv, lib, fetchHumbleBundle, unzip, SDL2, libGL, writeText, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "guacamelee-${version}";
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper ];
 
   buildPhase = let
-    rpath = stdenv.lib.makeLibraryPath [ SDL2 stdenv.cc.cc libGL ];
-    fmodRpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc ];
+    rpath = lib.makeLibraryPath [ SDL2 stdenv.cc.cc libGL ];
+    fmodRpath = lib.makeLibraryPath [ stdenv.cc.cc ];
   in ''
     gcc -Werror -shared "$preloader" -o preloader.so -ldl \
       -DDATA=\"$out/share/guacamelee\"

--- a/pkgs/games/humblebundle/hammerwatch.nix
+++ b/pkgs/games/humblebundle/hammerwatch.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, makeWrapper, unzip, mono, SDL2, libGL, openal
+{ stdenv, lib, fetchHumbleBundle, makeWrapper, unzip, mono, SDL2, libGL, openal
 , pulseaudio
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ unzip makeWrapper ];
 
   installPhase = let
-    rpath = stdenv.lib.makeLibraryPath [ SDL2 libGL openal pulseaudio ];
+    rpath = lib.makeLibraryPath [ SDL2 libGL openal pulseaudio ];
     monoNoLLVM = mono.override { withLLVM = false; };
   in ''
     mkdir -p "$out/lib"

--- a/pkgs/games/humblebundle/jamestown.nix
+++ b/pkgs/games/humblebundle/jamestown.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchHumbleBundle, unzip, pkgsi686Linux, expect, makeWrapper
+{ stdenv, lib, fetchHumbleBundle, unzip, pkgsi686Linux, expect, makeWrapper
 , SDL, openal
 }:
 
 let
   version = "1.0.2";
-  usVersion = stdenv.lib.replaceChars ["."] ["_"] version;
+  usVersion = lib.replaceChars ["."] ["_"] version;
 in stdenv.mkDerivation rec {
   name = "jamestown-${version}";
 
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
   '';
 
   installPhase = let
-    rpath = stdenv.lib.makeLibraryPath [ SDL openal ];
+    rpath = lib.makeLibraryPath [ SDL openal ];
   in ''
     libexec="$out/libexec/jamestown"
     install -vD Jamestown-amd64 "$libexec/jamestown"

--- a/pkgs/games/humblebundle/pico-8.nix
+++ b/pkgs/games/humblebundle/pico-8.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, SDL2, unzip, xorg, libudev, alsaLib, dbus
+{ stdenv, lib, fetchHumbleBundle, SDL2, unzip, xorg, libudev, alsaLib, dbus
 , libpulseaudio, libdrm, libvorbis, json_c }:
 
 stdenv.mkDerivation rec {
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   phases = [ "unpackPhase" "buildPhase" "installPhase" ];
 
   buildPhase = let
-    rpath = stdenv.lib.makeLibraryPath [
+    rpath = lib.makeLibraryPath [
       stdenv.cc.cc SDL2 xorg.libXxf86vm xorg.libXcursor xorg.libXi
       xorg.libXrandr libudev alsaLib dbus
       libpulseaudio libdrm libvorbis json_c

--- a/pkgs/games/humblebundle/spaz.nix
+++ b/pkgs/games/humblebundle/spaz.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   buildPhase = let
-    libs = pkgsi686Linux.stdenv.lib.makeLibraryPath [
+    libs = pkgsi686Linux.lib.makeLibraryPath [
       pkgsi686Linux.stdenv.cc.cc pkgsi686Linux.SDL
     ];
   in ''
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = let
-    libs = pkgsi686Linux.stdenv.lib.makeLibraryPath [
+    libs = pkgsi686Linux.lib.makeLibraryPath [
       pkgsi686Linux.libGL pkgsi686Linux.openal pkgsi686Linux.alsaPlugins
     ];
   in ''

--- a/pkgs/games/humblebundle/swordsandsoldiers.nix
+++ b/pkgs/games/humblebundle/swordsandsoldiers.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, makeWrapper
+{ stdenv, lib, fetchHumbleBundle, makeWrapper
 , SDL, libGL, zlib, openal, libvorbis, xorg, fontconfig, freetype, libogg
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper ];
 
   patchPhase = let
-    rpath = stdenv.lib.makeLibraryPath [
+    rpath = lib.makeLibraryPath [
       SDL libGL zlib openal libvorbis fontconfig freetype stdenv.cc.cc libogg
       xorg.libX11 xorg.libXft xorg.libXinerama xorg.libXext xorg.libXpm
     ];

--- a/pkgs/games/humblebundle/unepic.nix
+++ b/pkgs/games/humblebundle/unepic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchHumbleBundle, unzip, makeWrapper, SDL2, SDL2_mixer, zlib }:
+{ stdenv, lib, fetchHumbleBundle, unzip, makeWrapper, SDL2, SDL2_mixer, zlib }:
 
 let
   version = "1.50.5";
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ unzip makeWrapper ];
 
   installPhase = let
-    rpath = stdenv.lib.makeLibraryPath [ SDL2 SDL2_mixer zlib stdenv.cc.cc ];
+    rpath = lib.makeLibraryPath [ SDL2 SDL2_mixer zlib stdenv.cc.cc ];
   in ''
     dest="$out/opt/games/unepic"
     exe="$dest/unepic${arch}"

--- a/pkgs/games/steam/fetchsteam/default.nix
+++ b/pkgs/games/steam/fetchsteam/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, writeText, fetchFromGitHub, buildDotnetPackage
+{ stdenv, lib, runCommand, writeText, fetchFromGitHub, buildDotnetPackage
 , username, password
 }:
 
@@ -65,18 +65,18 @@ let
     # without that nasty wrapper.
     makeWrapperArgs = let
       mkMono = name: path: "${path}/lib/dotnet/${name}";
-      paths = stdenv.lib.mapAttrsToList mkMono {
+      paths = lib.mapAttrsToList mkMono {
         inherit SteamKit2 protobuf-net;
       };
-      monoPath = stdenv.lib.concatStringsSep ":" paths;
+      monoPath = lib.concatStringsSep ":" paths;
     in [ "--prefix MONO_PATH : \"${monoPath}\"" ];
   };
 
   fileListFile = let
-    content = stdenv.lib.concatStringsSep "\n" fileList;
+    content = lib.concatStringsSep "\n" fileList;
   in writeText "steam-file-list-${name}.txt" content;
 
-in with stdenv.lib; runCommand "${name}-src" {
+in with lib; runCommand "${name}-src" {
   buildInputs = [ DepotDownloader ];
   inherit username password appId depotId manifestId;
   preferLocalBuild = true;

--- a/pkgs/profpatsch/default.nix
+++ b/pkgs/profpatsch/default.nix
@@ -45,7 +45,7 @@ let
     in import src { nixpkgs = pkgs; };
 
   testing = import ./testing {
-    inherit stdenv lib;
+    inherit lib;
     inherit (runExeclineFns) runExecline;
     inherit (pkgs) runCommandLocal;
     bin = getBins pkgs.s6PortableUtils [ "s6-touch" "s6-echo" ];

--- a/pkgs/profpatsch/sfttime/default.nix
+++ b/pkgs/profpatsch/sfttime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, bc }:
+{ stdenv, lib, makeWrapper, bc }:
 
 stdenv.mkDerivation {
   name = "sfttime";
@@ -9,6 +9,6 @@ stdenv.mkDerivation {
   installPhase = ''
     install -D ${./sfttime.sh} $out/bin/sfttime
     wrapProgram $out/bin/sfttime \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ bc ]}
+      --prefix PATH : ${lib.makeBinPath [ bc ]}
   '';
 }

--- a/pkgs/profpatsch/testing/default.nix
+++ b/pkgs/profpatsch/testing/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommandLocal, lib
+{ runCommandLocal, lib
 , runExecline, bin }:
 
 let


### PR DESCRIPTION
Upstream is deprecating `stdenv.lib`, so let’s do the same.