### PR TITLE
pkgs/tvl: expose tvl's depot in vuizvui

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,7 +1,12 @@
 { pkgs ? import (import ../nixpkgs-path.nix) {} }:
 
 let
-  inherit (pkgs.lib) callPackageWith;
+  inherit (pkgs.lib)
+    callPackageWith
+    recurseIntoAttrs
+    dontRecurseIntoAttrs
+    ;
+
   callPackage = callPackageWith (pkgs // self.vuizvui);
   callPackage_i686 = callPackageWith (pkgs.pkgsi686Linux // self.vuizvui);
 
@@ -10,7 +15,7 @@ let
     pkgsi686Linux = pkgs.pkgsi686Linux // self.vuizvui;
   };
 
-  self.vuizvui = pkgs.recurseIntoAttrs {
+  self.vuizvui = recurseIntoAttrs {
     mkChannel = callPackage ./build-support/channel.nix { };
     buildSandbox = callPackage ./build-support/build-sandbox {};
     lazy-packages = callPackage ./build-support/lazy-packages {};
@@ -30,5 +35,7 @@ let
     openlab = callPackageScope ./openlab;
     profpatsch = callPackageScope ./profpatsch;
     sternenseemann = callPackageScope ./sternenseemann;
+
+    tvl = dontRecurseIntoAttrs (callPackage ./tvl { });
   };
 in self.vuizvui

--- a/pkgs/tvl/default.nix
+++ b/pkgs/tvl/default.nix
@@ -1,0 +1,12 @@
+{ tvlSrc ? builtins.fetchGit {
+    name = "tvl-depot";
+    url = "https://code.tvl.fyi";
+    rev = "98371362f25202f8afae3949b618b0db78d5ea1d";
+    ref = "canon";
+  }
+, pkgs
+}:
+
+import tvlSrc {
+  nixpkgsBisectPath = pkgs.path; # TODO: does this improve eval time significantly?
+}


### PR DESCRIPTION
depot is a nix-based monorepo which contains some great nix utilities
like yants (a nix type system), runTestsuite, mergePatch and so on, a
few interesting pure nix builders like buildLisp and buildGo and a few
packages maintained by @Profpatsch and myself.

This change exposes tvl completely as pkgs.tvl, but prevents hydra from
building it using dontRecurseIntoAttrs as depot pins its own version of
nixpkgs which is not easily overrideable, contains some expensive to
build system configurations we are not interested in and even some
notoriously indeterministic packages.

Additionally it is possible to override pkgs.tvl to use a different or
local version of depot:

    pkgs.tvl.override { tvlSrc = /home/lukas/src/depot; }

Since depot is pinned to a specific revision (and there are no force
pushes) as well as depot's nixpkgs there should be no breakage caused by
depot on its own.

Downsides of the current approach:

* Hydra only builds tvl packages if they are otherwise used (in vuizvui
  pkgs or machines). Probably an upside rather than a downside.
* builtins.fetchGit

Alternatives:

* Vendoring in depot. Probably not desireable as it would explode
  vuizvuis size.
* Only exposing a subset of tvl, but also exposing it to hydra.
* Have a <tvl> channel?
* Vendor in stuff we need and keep it updated manually.
* ~~flakes~~

Future work:

* Get tvl to generate tarballs for git revisions so we can use
  builtins.fetchTarball and pin a hash instead of relying on fetchGit's
  caching behavior (I think fetchGit is fine and caches infinitely if a
  revision is set, but I don't know for sure as it is not documented)
* Make globally overriding tvlSrc more convenient either via an entry
  in the vuizvui config (like for pkgs.games credentials) or via some
  kind of vuizvui overlay support.
* Generally improve the story of including nix-based monorepos without
  flakes by expanding on stuff like
  <https://code.tvl.fyi/about/docs/designs/SPARSE_CHECKOUTS.md>
  and making it actually usable (with nix).