### PR TITLE
modules/core/common: disable programs.command-not-found by default

### DIFF
--- a/modules/core/common.nix
+++ b/modules/core/common.nix
@@ -70,5 +70,9 @@ with lib;
         rootChannelsPath
       ] ++ optional config.vuizvui.enableGlobalNixpkgsConfig nixpkgsConfig;
     in mkIf config.vuizvui.modifyNixPath (mkOverride 90 nixPath);
+
+    # the vuizvui channel doesn't provide a programs.sqlite database, so
+    # command-not-found will just result in errors
+    programs.command-not-found.enable = lib.mkDefault false;
   };
 }


### PR DESCRIPTION
programs.command-not-found.enable defaults to true. While it is a neat
feature, it doesn't work with vuizvui because we don't provide a
programs.sqlite database which is required by command-not-found.

Disabling this by default solves the nasty error messages in for example
the default fish configuration if you try to execute a command which is
not installed.

Users which build a custom programs.sqlite database can still enable the
program themselves.