### PR TITLE
modules/user/profpatsch: description for services.dunst.settings

### DIFF
--- a/modules/user/profpatsch/services/dunst.nix
+++ b/modules/user/profpatsch/services/dunst.nix
@@ -48,6 +48,12 @@ in {
     settings = lib.mkOption {
       type = with lib.types; attrsOf (attrsOf eitherStrBoolIntList);
       default = { };
+      description = ''
+        Settings for the dunst daemon which are directly translated
+        to the used <literal>dunstrc</literal> config file. See
+        <link xlink:href="https://github.com/dunst-project/dunst/blob/v${pkgs.dunst.version}/dunstrc" />
+        for a list of available options.
+      '';
     };
 
     iconTheme = lib.mkOption {


### PR DESCRIPTION
This is not really to inform anybody about anything, but mostly to get rid of the warning generated by `nix-build -A manual release.nix`.