### PR TITLE
modules/user/profpatsch: adjust naming scheme

### DIFF
--- a/machines/profpatsch/legosi.nix
+++ b/machines/profpatsch/legosi.nix
@@ -73,7 +73,7 @@ in {
       root.openssh.authorizedKeys.keys = [ myKey ];
     };
 
-    vuizvui.programs.profpatsch.weechat = {
+    vuizvui.user.profpatsch.programs.weechat = {
       enable = true;
       authorizedKeys = [ myKey ];
       # redirect the bitlbee unix socket to a fake domain
@@ -81,12 +81,12 @@ in {
       wrapExecStart = [
         "${pkgs.ip2unix}/bin/ip2unix"
         "-r"
-        "addr=1.2.3.4,port=6667,path=${config.vuizvui.services.profpatsch.bitlbee.socketFile}"
+        "addr=1.2.3.4,port=6667,path=${config.vuizvui.user.profpatsch.services.bitlbee.socketFile}"
       ];
     };
     users.users.weechat.extraGroups = [ "bitlbee" ];
 
-    vuizvui.services.profpatsch.bitlbee = {
+    vuizvui.user.profpatsch.services.bitlbee = {
        enable = true;
     };
 

--- a/machines/profpatsch/shiki.nix
+++ b/machines/profpatsch/shiki.nix
@@ -368,7 +368,7 @@ in {
 
     ################
     # User services
-    vuizvui.services.profpatsch.dunst = {
+    vuizvui.user.profpatsch.services.dunst = {
       enable = true;
       settings = {
         global = {

--- a/modules/README.md
+++ b/modules/README.md
@@ -36,7 +36,9 @@ When writing modules, make sure to categorize them accordingly:
 </table>
 
 If a module is highly specific to your own configuration, use the same
-categories but put them under `user/$category/$module`.
+categories but put them under `user/$username/$category/$module`.
+Their configuration options should be named
+`vuizvui.user."${username}".*` accordingly.
 
 Don't forget to add your module to `module-list.nix`, but make sure you have
 options in place to disable them by default.

--- a/modules/user/profpatsch/programs/weechat.nix
+++ b/modules/user/profpatsch/programs/weechat.nix
@@ -8,7 +8,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  cfg = config.vuizvui.programs.profpatsch.weechat;
+  cfg = config.vuizvui.user.profpatsch.programs.weechat;
   weechatDataDir = "/var/lib/weechat";
   sessionName = "weechat";
   userName = "weechat";
@@ -64,7 +64,7 @@ let
 in
 
 {
-  options.vuizvui.programs.profpatsch.weechat = {
+  options.vuizvui.user.profpatsch.programs.weechat = {
     enable = lib.mkEnableOption "weechat";
 
     authorizedKeys = lib.mkOption {

--- a/modules/user/profpatsch/services/bitlbee.nix
+++ b/modules/user/profpatsch/services/bitlbee.nix
@@ -3,7 +3,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  cfg = config.vuizvui.services.profpatsch.bitlbee;
+  cfg = config.vuizvui.user.profpatsch.services.bitlbee;
   bitlbeeUsername = "bitlebee";
   stateDir = "bitlbee";
 
@@ -29,7 +29,7 @@ in
 
   options = {
 
-    vuizvui.services.profpatsch.bitlbee = {
+    vuizvui.user.profpatsch.services.bitlbee = {
 
       enable = lib.mkEnableOption "bitlbee";
 

--- a/modules/user/profpatsch/services/dunst.nix
+++ b/modules/user/profpatsch/services/dunst.nix
@@ -4,7 +4,7 @@
 { pkgs, lib, config, ... }:
 
 let
-  cfg = config.vuizvui.services.profpatsch.dunst;
+  cfg = config.vuizvui.user.profpatsch.services.dunst;
 
   eitherStrBoolIntList = with lib.types;
     either str (either bool (either int (listOf str)));
@@ -42,7 +42,7 @@ let
   themeSize = "32x32";
 
 in {
-  options.vuizvui.services.profpatsch.dunst = {
+  options.vuizvui.user.profpatsch.services.dunst = {
     enable = lib.mkEnableOption "dunst libnotify server";
 
     settings = lib.mkOption {
@@ -70,7 +70,7 @@ in {
     };
 
 
-    vuizvui.services.profpatsch.dunst.settings = {
+    vuizvui.user.profpatsch.services.dunst.settings = {
       global = {
         icon_position = "left";
         icon_path = let


### PR DESCRIPTION
The general consensus seems to be to use

    vuizvui.user.<username>.<category>.<module name>

instead of

    vuizvui.<category>.<user name>.<module name>

Things done to test this change:

* Checked build of `machines.profpatsch.legosi.build`
* Checked evaluation of `machines.profpatsch.shiki.build` (friendly reminder to fix the build of `nix-gen` and `dhall-flycheck`!)