### PR TITLE
pkgs/profpatsch/nix-gen: unbreak by un-pinning hnix

### DIFF
--- a/pkgs/profpatsch/utils-hs/default.nix
+++ b/pkgs/profpatsch/utils-hs/default.nix
@@ -40,28 +40,10 @@ let
           preferLocalBuild = true;
           allowSubstitutes = false;
         });
-
-        these = hlib.doJailbreak hsuper.these;
-
-        hnix = hlib.overrideCabal
-          (hsuper.hnix.override {
-            inherit (hself) these;
-          }) (old: {
-          src = fetchFromGitHub {
-            owner = "haskell-nix";
-            repo = "hnix";
-            rev = "e7efbb4f0624e86109acd818942c8cd18a7d9d3d";
-            sha256 = "0dismb9vl5fxynasc2kv5baqyzp6gpyybmd5p9g1hlcq3p7pfi24";
-          };
-          broken = false;
-          buildDepends = old.buildDepends or [] ++ (with hself; [
-            dependent-sum prettyprinter (hlib.doJailbreak ref-tf)
-          ]);
-        });
       });
     };
 
-  haskellDrv = { name, subfolder, deps }: hps.mkDerivation {
+  haskellDrv = { name, subfolder, deps, ... }@args: hps.mkDerivation ({
     pname = name;
     inherit version;
     src = "${utilsSrc}/${subfolder}";
@@ -78,13 +60,14 @@ let
     isLibrary = false;
     doHaddock = false;
     postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
-  };
+  } // builtins.removeAttrs args [ "name" "subfolder" "deps" ]);
 
 
   nix-gen = haskellDrv {
     name = "nix-gen";
     subfolder = "nix-gen";
     deps = with hps; [ hnix ansi-wl-pprint protolude data-fix ];
+    jailbreak = true;
   };
 
   until = haskellDrv {


### PR DESCRIPTION
Pinning dependencies without pinning nixpkgs seems to be trading in
having it maybe break tomorrow for having it definitely break in a few
months: `nix-gen` builds fine with a more recent `hnix` as well, but
requires a jailbreak to do so.

Should probably fixed in upstream utils.hs as well.