### PR TITLE
channels: inject programs.sqlite from nixos channel into vuizvui

### DIFF
--- a/machines/sternenseemann/base.nix
+++ b/machines/sternenseemann/base.nix
@@ -18,9 +18,6 @@ in {
     nix.extraOptions = "gc-keep-derivations = false";
     nixpkgs.config.allowUnfree = true;
 
-    # doesn't work with vuizvui atm
-    programs.command-not-found.enable = false;
-
     services.journald.extraConfig = lib.mkDefault "SystemMaxUse=500M";
 
     console.keyMap = lib.mkDefault "de-latin1";

--- a/modules/core/common.nix
+++ b/modules/core/common.nix
@@ -2,7 +2,11 @@
 
 with lib;
 
-{
+let
+  rootChannelsPath = "/nix/var/nix/profiles/per-user/root/channels";
+  channelPath = "${rootChannelsPath}/${config.vuizvui.channelName}";
+
+in {
   options.vuizvui = {
     modifyNixPath = mkOption {
       type = types.bool;
@@ -55,8 +59,6 @@ with lib;
     in mkIf config.vuizvui.enableGlobalNixpkgsConfig (mkForce nixpkgsCfg);
 
     nix.nixPath = let
-      rootChannelsPath = "/nix/var/nix/profiles/per-user/root/channels";
-      channelPath = "${rootChannelsPath}/${config.vuizvui.channelName}";
       nixosConfig = "/etc/nixos/configuration.nix";
       nixpkgsConfig = "nixpkgs-config=${pkgs.writeText "nixpkgs-config.nix" ''
         (import ${pkgs.path}/nixos/lib/eval-config.nix {
@@ -70,5 +72,9 @@ with lib;
         rootChannelsPath
       ] ++ optional config.vuizvui.enableGlobalNixpkgsConfig nixpkgsConfig;
     in mkIf config.vuizvui.modifyNixPath (mkOverride 90 nixPath);
+
+    # correct path used by command-not-found which is enabled by default
+    programs.command-not-found.dbPath =
+      mkDefault "${channelPath}/nixpkgs/programs.sqlite";
   };
 }

--- a/pkgs/sternenseemann/default.nix
+++ b/pkgs/sternenseemann/default.nix
@@ -116,4 +116,9 @@ lib.fix (self: {
   };
 
   unicode_clock = python3Packages.callPackage ./unicode_clock { };
+
+  vuizvui-update-programs-sqlite = python3Packages.callPackage ./vuizvui-update-programs-sqlite {
+    inherit (pkgs.writers) writePython3;
+    inherit (profpatsch) getBins;
+  };
 })

--- a/pkgs/sternenseemann/vuizvui-update-programs-sqlite/default.nix
+++ b/pkgs/sternenseemann/vuizvui-update-programs-sqlite/default.nix
@@ -1,0 +1,113 @@
+{ writePython3
+, getBins
+, requests
+, nix
+, gnutar
+}:
+
+let
+
+  bins = (getBins nix [ "nix-hash" ])
+      // (getBins gnutar [ "tar" ]);
+
+in
+
+writePython3 "vuizvui-update-programs-sqlite" {
+  flakeIgnore = [
+    # whitespaces around { }
+    "E201" "E202"
+    # fuck 4-space indentation
+    "E121" "E111"
+    # who cares about blank lines
+    "W391" "E302" "E305"
+    # URLs are long
+    "E501"
+  ];
+  libraries = [ requests ];
+} ''
+  from pathlib import Path
+  import re
+  import requests
+  import subprocess
+  import sys
+  from tempfile import TemporaryDirectory
+
+  def latest_nixexprs_url():
+    r = requests.head('https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz')
+
+    assert r.status_code == 301
+    return r.headers['location']
+
+  def nixos_version_for_url(url):
+    match = re.match(r"https://releases\.nixos\.org/nixos/unstable/nixos-([0-9a-fpre.]+)/nixexprs\.tar\.xz", url)
+    return match.group(1)
+
+  def download(url: str, filename: Path) -> Path:
+    with requests.get(url, stream=True) as r:
+      r.raise_for_status()
+      with open(filename, 'wb') as f:
+        for c in r.iter_content(chunk_size=16384):
+          f.write(c)
+
+    return filename
+
+  def main():
+    if len(sys.argv) > 2:
+        print(f'Usage: {sys.argv[0]} /path/to/release.nix', file=sys.stderr)
+        raise SystemExit(64)
+
+    url = latest_nixexprs_url()
+    version = nixos_version_for_url(url)
+
+    print(f'Updating programs.sqlite to {version}', file=sys.stderr)
+
+    with TemporaryDirectory(prefix="vuizvui-update-programs-sqlite") as dir:
+      nixexprs = download(url, dir / Path('nixexprs.tar.xz'))
+      programs_sqlite = dir / Path('programs.sqlite')
+
+      with open(programs_sqlite, 'wb') as f:
+        subprocess.run([
+            '${bins.tar}',
+            '-xJOf',
+            nixexprs,
+            f'nixos-{version}/programs.sqlite'
+          ], stdout=f, check=True)
+
+      hash = subprocess.run([
+          '${bins.nix-hash}',
+          '--base32',
+          '--type', 'sha256',
+          '--flat',
+          programs_sqlite
+        ],
+        check=True,
+        capture_output=True).stdout.decode('utf-8').strip()
+
+      print(f'New hash: {hash}', file=sys.stderr)
+
+      if len(sys.argv) == 1:
+        print('Doing nothing (dry run)', file=sys.stderr)
+      elif len(sys.argv) == 2:
+        release_nix = Path(sys.argv[1])
+
+        with open(release_nix, 'r+') as f:
+          text = f.read()
+          # base32 alphabet as per nix-rust/src/util/base32.rs
+          new_text = re.sub(r'programsSqliteSha256\s*=\s*"[0-9a-fg-np-sv-z]+"',
+                            f'programsSqliteSha256 = "{hash}"',
+                            text)
+          new_text = re.sub(r'programsSqliteVersion\s*=\s*"[0-9a-fpre.]+"',
+                            f'programsSqliteVersion = "{version}"',
+                            new_text)
+
+          if text == new_text:
+            print('Already up to date')
+          else:
+            f.seek(0)
+            f.write(new_text)
+
+            print(f'Wrote to {release_nix}', file=sys.stderr)
+
+  if __name__ == '__main__':
+    main()
+  ''


### PR DESCRIPTION
As discussed in #43 we can actually reuse the `programs.sqlite` from `nixos-unstable` quite easily and inject it into our redistribution of `nixpkgs` in the vuizvui channels.

~~This is achieved by adding a new input, `channelSrc` which may be pointed to an extracted `nixexprs.tar.xz`. If it is not given, no `programs.sqlite` is added.~~

~~The distinction between `channelSrc` and `nixpkgsSrc` allows us to get nixpkgs in something else than channel form and using different versions of both: Since building the database is quite expensive, using an outdated one is preferrable to building an index for the current version.~~

~~Tested by building the channel for wolfgang:~~
