### PR TITLE
modules/thinkpad: load the acpi_call kernel module for TLP

### DIFF
--- a/modules/hardware/thinkpad.nix
+++ b/modules/hardware/thinkpad.nix
@@ -27,5 +27,15 @@ in
 
     # TLP Linux Advanced Power Management
     services.tlp.enable = mkDefault true;
+    boot = {
+      # acpi_call is required for some tlp features, e.g. discharge/recalibrate
+      kernelModules = [
+        "acpi_call"
+      ];
+
+      extraModulePackages = [
+        config.boot.kernelPackages.acpi_call
+      ];
+    };
   };
 }


### PR DESCRIPTION
This kernel module is required for some operations supported by
TLP (e.g. tlp recalibrate), so we should enable it and be it to prevent
confusing error messages (as I encountered).