### PR TITLE
treewide: s6-test is dead, long live eltest!

### DIFF
--- a/modules/user/profpatsch/programs/weechat.nix
+++ b/modules/user/profpatsch/programs/weechat.nix
@@ -27,8 +27,9 @@ let
   bins = getBins pkgs.tmux [ "tmux" ]
     // getBins weechat-with-scripts [ "weechat" ]
     // getBins pkgs.dash [ "dash" ]
-    // getBins pkgs.s6-portable-utils [ "s6-sleep" "s6-test" ]
+    // getBins pkgs.s6-portable-utils [ "s6-sleep" ]
     // getBins pkgs.mosh [ "mosh-server" ]
+    // getBins pkgs.execline [ "eltest" ]
     ;
 
 
@@ -60,7 +61,7 @@ let
   attachWeechatTmuxSession = writeExecline "attach-weechat-tmux-session" {} [
     "importas" "-u" "-D" "" "what" "SSH_ORIGINAL_COMMAND"
     # if the user passes "ssh" as argv, it will call tmux directly
-    "ifelse" [ bins.s6-test "$what" "=" "ssh" ]
+    "ifelse" [ bins.eltest "$what" "=" "ssh" ]
     [ bins.tmux "attach-session" "-t" sessionName ]
     # if not, it uses the mosh-server (default)
     bins.mosh-server "--"

--- a/pkgs/profpatsch/default.nix
+++ b/pkgs/profpatsch/default.nix
@@ -87,11 +87,12 @@ let
         inherit stdenv;
         bin = (getBins pkgs.execline [
                  "execlineb"
+                 "eltest"
                  { use = "if"; as = "execlineIf"; }
                  "redirfd" "importas"
                ])
            // (getBins pkgs.s6-portable-utils
-                [ "s6-cat" "s6-grep" "s6-touch" "s6-test" "s6-chmod" ]);
+                [ "s6-cat" "s6-grep" "s6-touch" "s6-chmod" ]);
        };
     in {
       runExecline = it;

--- a/pkgs/profpatsch/execline/e.nix
+++ b/pkgs/profpatsch/execline/e.nix
@@ -2,7 +2,7 @@
 let
 
   bins = getBins pkgs.rlwrap [ "rlwrap" ]
-    // getBins pkgs.s6-portable-utils [ { use = "s6-cat"; as = "cat"; } "s6-test" ]
+    // getBins pkgs.s6-portable-utils [ { use = "s6-cat"; as = "cat"; } ]
     // getBins pkgs.execline [ "execlineb" ];
 
   # minimal execline shell

--- a/pkgs/profpatsch/execline/run-execline-tests.nix
+++ b/pkgs/profpatsch/execline/run-execline-tests.nix
@@ -81,7 +81,7 @@ let
     };
   } [
     "importas" "-ui" "v" "myvar"
-    "if" [ bin.s6-test "myvalue" "=" "$v" ]
+    "if" [ bin.eltest "myvalue" "=" "$v" ]
       "importas" "out" "out"
       bin.s6-touch "$out"
   ];

--- a/pkgs/profpatsch/execline/symlink.nix
+++ b/pkgs/profpatsch/execline/symlink.nix
@@ -13,7 +13,6 @@ runExecline name {
         (toNetstring dest + (toNetstring orig)))
       links;
     passAsFile = [ "pathTuples" ];
-    # bah! coreutils just for cat :(
     PATH = lib.makeBinPath [ s6-portable-utils ];
   };
 } [
@@ -31,7 +30,7 @@ runExecline name {
       "s6-mkdir" "-p" "$d"
     ]
 
-    "ifthenelse" [ "s6-test" "-L" "$orig" ] [
+    "ifthenelse" [ "eltest" "-L" "$orig" ] [
       "backtick" "-n" "res" [ "s6-linkname" "-f" "$orig" ]
       "importas" "-ui" "res" "res"
       "s6-ln" "-fs" "$res" "$dest"

--- a/pkgs/profpatsch/xdg-open/default.nix
+++ b/pkgs/profpatsch/xdg-open/default.nix
@@ -17,7 +17,7 @@ let
       // getBins pkgs.coreutils [ "printf" "ln" "echo" ]
       // getBins pkgs.fdtools [ "multitee" ]
       // getBins pkgs.s6 [ "s6-ioconnect" ]
-      // getBins pkgs.s6-portable-utils [ "s6-test" ]
+      // getBins pkgs.execline [ "eltest" ]
       // getBins pkgs.s6-networking [ "s6-tcpclient" ]
       // getBins pkgs.libressl.nc [ "nc" ]
       // getBins pkgs.dmenu [ "dmenu" "dmenu_path" ]
@@ -199,8 +199,8 @@ let
 
   http-request = writeExecline "http-request" { } [
     "importas" "-i" "protocol" "protocol"
-    "ifelse" [ bins.s6-test "$protocol" "=" "http" ] [ (http-https-request false) ]
-    "ifelse" [ bins.s6-test "$protocol" "=" "https" ] [ (http-https-request true) ]
+    "ifelse" [ bins.eltest "$protocol" "=" "http" ] [ (http-https-request false) ]
+    "ifelse" [ bins.eltest "$protocol" "=" "https" ] [ (http-https-request true) ]
     eprintf "protocol \${protocol} not supported"
   ];
 
@@ -274,7 +274,7 @@ let
       record-get [ "status" "status-text" "headers" ]
       "importas" "-ui" "status" "status"
       # TODO: a test util for netencode values
-      "ifelse" [ bins.s6-test "$status" "=" "n6:301," ]
+      "ifelse" [ bins.eltest "$status" "=" "n6:301," ]
       # retry the redirection location
       [ as-stdin "headers"
         record-get [ "Location" ]


### PR DESCRIPTION
Recent versions of s6-portable-utils no longer include s6-test which was deprecated in favor of eltest which supposedly has the same interface.

I've not tested this commit very thoroughly, but my system now builds again with recent nixpkgs commits (I think I dependended on s6-test via the rust writer via nman).

cc @Profpatsch