### PR TITLE
pkgs/profpatsch/nman: ✨ add --local flag to use local default.nix

### DIFF
--- a/pkgs/profpatsch/nman/nman.1
+++ b/pkgs/profpatsch/nman/nman.1
@@ -6,7 +6,7 @@
 .Nd nix-shell for man pages
 .Sh SYNOPSIS
 .Nm
-.Op Fl hv
+.Op Fl hvl
 .Ar ATTR
 .Op Ar PAGE | SECTION Op PAGE
 .Sh DESCRIPTION
@@ -80,6 +80,13 @@ Print usage information.
 Put
 .Nm
 into verbose mode, where it prints all commands it executes.
+.It Fl -local | l
+Use
+.Pa ./default.nix
+in the current directory instead of
+.Ql <nixpkgs>
+from the Nix search path. This allows using local package definitions
+or custom package sets.
 .El
 
 .Sh EXAMPLES
@@ -97,6 +104,12 @@ nman mandoc man
 
 # open man(7) from the same package
 nman mandoc 7 man
+
+# open lowdown(1) from local default.nix
+nman --local lowdown
+
+# open man page from a custom package set
+nman -l myCustomPackage
 .Ed
 .Sh DISCLAIMER
 .Nm


### PR DESCRIPTION
Add support for using ./default.nix instead of <nixpkgs> when the --local or -l flag is specified. This allows viewing man pages for packages defined in local development environments or custom package sets.

Changes:
- Add use_local field to Main struct
- Parse --local/-l command line option
- Conditionally use ./default.nix in Nix expression generation
- Update help text and man page documentation with new option and examples
- Maintain backward compatibility (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)