### PR TITLE
buildSandbox: add missing headers for Nix >= 2.29

### DIFF
--- a/pkgs/build-support/build-sandbox/src/nix-query.cc
+++ b/pkgs/build-support/build-sandbox/src/nix-query.cc
@@ -1,5 +1,11 @@
 #include <iostream>
 
+#if NIX_VERSION >= 231
+#include <nix/store/globals.hh>
+#endif
+#if NIX_VERSION >= 229
+#include <nix/store/store-open.hh>
+#endif
 #if NIX_VERSION >= 228
 #include <nix/store/local-fs-store.hh>
 #include <nix/store/config.hh>


### PR DESCRIPTION
Nix 2.29 and 2.31 shuffled headers around in a way that affects nix-query.cc:

- https://github.com/nixOS/nix/commit/52212635db147cb2f09d8e39e873abe00c525371
- https://github.com/nixos/nix/commit/d972f9e2e250d386c44ee58bd78113ca0a976ff0